### PR TITLE
Simplify activity saving

### DIFF
--- a/src/components/ActivityInput.vue
+++ b/src/components/ActivityInput.vue
@@ -108,8 +108,24 @@
         </form>
 
         <!-- Save/delete buttons -->
-        <div :class="[space.paddingTop, space.marginTop, border.top]">
+        <div :class="[space.paddingTop, space.marginTop, border.top, base.buttonContainer]">
           <BaseGutterWrapper gutterX="narrow" gutterY="narrow">
+            <li :class="base.buttonWrapper" v-if="getActivity()">
+              <BaseButton
+                @click="addActivity"
+                :label="$t('save')"
+                size="small"
+                :role="'primary'"
+              />
+            </li>
+            <li :class="base.buttonWrapper" v-if="!getActivity()">
+              <BaseButton
+                @click="addActivity"
+                :label="$t('save')"
+                size="small"
+                :role="'primary'"
+              />
+            </li>
             <li :class="base.buttonWrapper">
               <BaseButton
                 v-if="getActivity()"
@@ -173,6 +189,11 @@ export default {
     }
   },
   computed: {
+    canSubmit: function() {
+      const activityInstance = this.getActivity();
+
+      return !! activityInstance;
+    },
     activityTypeOptions: function () {
       return this.getActvityData().map(activityType => {
         return {
@@ -221,15 +242,13 @@ export default {
       window.open(routeData.href, '_blank');
     },
     saveOnChange: function () {
-      if (this.activityType && this.activityText) {
-        this.addActivity()
-        this.informParent(true)
+      if (this.canSubmit) {
+        this.addActivity(false)
       } else {
         this.informParent(false)
       }
     },
     informParent: function (bool) {
-      console.log('testing', this.activityId)
       // Tells parent whether the form is complete or not.
       this.$emit('changed', bool, this.activityId)
     },
@@ -279,7 +298,7 @@ export default {
         this.currentActivityID = this.activityId
         this.activityText = activityInstance.text
         this.activityNumber = activityInstance.activityNumber
-        this.informParent(true)
+        this.informParent(false)
         return
       }
       this.currentActivityID = this.activityId
@@ -291,6 +310,16 @@ export default {
       this.activityText = ''
       this.activityNumber = ''
       this.informParent(false)
+    },
+    clearForm: function() {
+      this.currentActivityID = this.activityId
+      this.existingActivity = {}
+      this.activityBudgetBase = null
+      this.activityBudgetScale = this.budgetScaleOptions[0]
+      this.activityYouthCentric = false
+      this.activityType = ''
+      this.activityText = ''
+      this.activityNumber = ''
     },
     getActivity: function (field = '') {
       const activityInstance = this.$store.getters['entities/activities/find'](
@@ -304,10 +333,10 @@ export default {
         return null
       }
     },
-    addActivity: function () {
+    addActivity: function (informParent = true) {
       // Add or update activity
       const activityInstance = this.getActivity()
-
+      
       this.$validator.validate().then(result => {
         // If valid, add or update activity, else show errors.
         if (result) {
@@ -331,6 +360,7 @@ export default {
               }
             })
           }
+          this.informParent(informParent);
           this.notify(this.$t('saveSuccess'), 'success')
           this.updateData()
         }
@@ -342,6 +372,7 @@ export default {
         Number(this.activityId)
       )
       this.notify(this.$t('deleteSuccess'), 'success')
+      // todo go to new activity page
     }
   },
   created () {
@@ -367,6 +398,10 @@ $budgetSelectWidth: 160px;
 
 .activityTypeWrapper {
   @include clearfix;
+}
+
+.buttonContainer {
+  text-align: right;
 }
 
 .infoBox {

--- a/src/components/BestPracticeInfoIcon.vue
+++ b/src/components/BestPracticeInfoIcon.vue
@@ -184,9 +184,7 @@ export default {
       })
     },
     toggleFlyout: function () {
-      console.log('toggle flyout')
       if (this.flyoutOpen) {
-        console.log('flyout is closed')
         // Tell the store this flyout is closed
         this.$store.commit('SET_INFO_FLYOUT', {})
         // this.$store.dispatch('entities/bestpracticeicons/create', {
@@ -198,7 +196,6 @@ export default {
         // })
       } else {
         // Tell the store this flyout is open
-        console.log('flyout is open')
         this.$store.commit('SET_INFO_FLYOUT', {
           activity_id: this.activityID,
           best_practice_id: this.id,

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -117,7 +117,7 @@ en:
   activityBudget: Activity budget
   activityType: Categorize your activity by type
   activityYouthCentric: Is this activity youth-centric?
-  inputNextActivity: Save & Add New Activity
+  inputNextActivity: Add New Activity
   activitiesDone: "Save & Finish"
   saveAndContinue: Save and Continue
   continue: Continue

--- a/src/views/Activity.vue
+++ b/src/views/Activity.vue
@@ -8,6 +8,7 @@
       ref="activityInput"
       :key="this.getLastItem()"
       @changed="trackValidation"
+      :canSubmit="isFormFilled"
     />
   </NavFooter>
 </template>
@@ -32,8 +33,6 @@ export default {
       return this.getNextActivity
     },
     currentActivity: function () {
-      console.log('next', this.nextActivity())
-      console.log('initial', 1)
       return this.$props.activityId || this.nextActivity()
     }
   },
@@ -50,24 +49,15 @@ export default {
   },
   methods: {
     trackValidation: function (value, activityId) {
-      this.isFormFilled = value
       // Go to completed activity on save
       if (value && activityId) {
+        // this.isFormFilled = value
         this.travelToActivity(activityId)
       }
     },
     travelToActivity: function (activityId) {
       const yOffset = window.pageYOffset
-      // If first activity
-      if (!this.$router.history.current.params.activityId) {
-        activityId = activityId - 1;
-      } 
-
-      if (this.$router.history.current.params.activityId !== activityId) {
-        this.$router.push({ name: 'activity', params: { activityId: activityId } })
-      }
-      
-      window.scroll(0, yOffset) // keep scroll position
+      window.scroll(0, 0) // move to top of form
     },
     goBack: function() {
       if (this.previousRoute) {
@@ -88,7 +78,7 @@ export default {
         right: []
       }
 
-      if (this.getItemCount('activities') > 0) {
+      if (this.$props.activityId) {
         navButtons.right.push(
           {
             to: { name: 'activity' },
@@ -96,13 +86,16 @@ export default {
             iconLeft: 'add',
             iconRight: 'none'
           },
-          {
+        )
+      }
+
+      navButtons.right.push(
+        {
             to: { name: 'summary' },
             label: this.$t('saveAndContinue'),
             role: this.isFormFilled ? 'primary' : 'default'
           }
-        )
-      }
+      )
 
       return navButtons
     }


### PR DESCRIPTION
This commit simplifies the activity saving process. When an activity is
input, the user will need to press the save button to submit a new
activity. This will clear the form and take the user to the top of the
form. If the users is editing an activity, the activity will be saved
with each input change. In order to avoid confusion, the save activity
button is still present in the edit view. From the edit activity view,
the user also has the option to add another activity or save the current
activity.