### PR TITLE
Use `activityNumber` as title in activity tray

### DIFF
--- a/src/components/ActivityTray.vue
+++ b/src/components/ActivityTray.vue
@@ -17,6 +17,14 @@
       :class="type.leadingDefault"
     >{{getActivityTitle()}}</BaseHeading>
 
+    <BaseBodyText
+      :class="base.activityText"
+      :content="getActivityText()"
+      size="zeta"
+      font="display"
+      weight="light"
+      />
+
     <div :class="[base.gutter, space.paddingTopNarrow]">
       <BaseDataGrid :data="expandedData" :class="base.dataList" :condensed="true" />
     </div>
@@ -189,6 +197,9 @@ export default {
       return type.title;
     },
     getActivityTitle: function() {
+      return this.activity.activityNumber;
+    },
+    getActivityText: function() {
       return this.activity.text;
     },
     isYouthCentric: function() {
@@ -216,6 +227,7 @@ export default {
 @import "~styleConfig/color";
 @import "~styleConfig/spacing";
 @import '~styleConfig/scale';
+@import '~styleConfig/type';
 
 .paddingHorizontalNone {
   padding-left: 0;

--- a/src/components/BaseBodyText.vue
+++ b/src/components/BaseBodyText.vue
@@ -1,7 +1,7 @@
 <template>
   <VueMarkdown
     :source="content"
-    :class="[base.content, type[font], type[typeScaleClass(size)]]"
+    :class="[base.content, type[font], type[weight], type[typeScaleClass(size)]]"
   ></VueMarkdown>
 </template>
 
@@ -29,6 +29,13 @@ export default {
       default: 'body',
       validator: function (value) {
         return ['body', 'display'].indexOf(value) !== -1
+      }
+    },
+    weight: {
+      type: String,
+      default: '',
+      validator: function (value) {
+        return ['bold', 'light'].indexOf(value) !== -1
       }
     }
   }


### PR DESCRIPTION
This commit fixes an issue where we were using the `text` value from the
activity in the activity tray as the title. This resulted in an
unreadable layout. This commit modifies the activity tray to use the
`activityNumber` as the title, and to display the `text` in the body.

**Before**
![image](https://user-images.githubusercontent.com/42478798/64907812-0c989500-d6bd-11e9-9492-483198fceeda.png)


**After**
![image](https://user-images.githubusercontent.com/42478798/64907815-115d4900-d6bd-11e9-91d0-af8218f885ab.png)
