### PR TITLE
Clean up Print view

### DIFF
--- a/src/components/ActivitiesItemAssessment.vue
+++ b/src/components/ActivitiesItemAssessment.vue
@@ -27,7 +27,7 @@
           :color="youth || numberIndex ? 'dark' : 'midtone'"
           sub
         >
-          {{displayText}}
+          {{displayNumber}}
         </BaseHeading>
       </template>
       <template slot="summaryRight">

--- a/src/views/Print.vue
+++ b/src/views/Print.vue
@@ -5,7 +5,81 @@
     :rightButtons="navButtons.right"
   >
     <!-- header and charts -->
-    <ResultsCharts :displayQuestions="false" />
+    <ResultsCharts />
+
+    <!-- Global Recommendations -->
+    <BaseSectionWrapper border>
+      <BaseHeading
+        :level="2"
+        :class="space.paddingBottom"
+        scale="gamma"
+      >
+        {{$t('print.globalRecommendations.title')}}
+      </BaseHeading>
+      <BaseWidthWrapper
+        :class="space.paddingBottom"
+      >
+        <BaseBodyText :content="$t('print.globalRecommendations.content')" />
+
+        <BaseVerticalList
+          :items="globalRecommendations"
+          :class="[space.paddingTop, space.marginTop, border.top, border.secondary]"
+        >
+          <template slot-scope="{ item, index }">
+            <template v-if="item.text">
+              <BaseHeading
+                :level="2"
+                :centered="false"
+                :class="space.paddingBottomXnarrow"
+                weight="bold"
+                color="midtone"
+                scale="epsilon"
+              >
+               {{ $t('print.globalRecommendations.recommendation', { count: index+1 }) }}
+              </BaseHeading>
+              <BaseBodyText :content="item.text" />
+            </template>
+          </template>
+        </BaseVerticalList>
+      </BaseWidthWrapper>
+
+    </BaseSectionWrapper>
+
+    <!-- Activities list -->
+    <BaseSectionWrapper :class="space.paddingTop" border>
+      <BaseWidthWrapper width="wide">
+        <!-- Count & export tools -->
+        <ActivitiesListHeader clearRecommendations />
+
+        <!-- Table -->
+        <ActivitiesList ref="activityList" v-bind:groupedActivities="groupedActivities">
+          <template #activities="{ activities, setActivityId }">
+            <div v-if="activities.activityObjects.length > 0">
+              <ActivitiesTypeHeading>
+                {{activities.activityTypeName}}
+                <template slot="stats">
+                  <BaseProgressBar
+                    :label="$t('results.activityWithEIPbyType')"
+                    :percentage="percentBPActivitesByType(activities.activityTypeKey)"
+                  />
+                </template>
+              </ActivitiesTypeHeading>
+              <ul :class="base.activityTypeList">
+                <ActivitiesItemAssessment
+                  v-for="(activity, index) in activities.activityObjects"
+                  :key="`activity-${index}`"
+                  :activity="activity"
+                  :youth="activity.youthCentric"
+                  @activitySelect="setActivityId"
+                  :class="[mountedActivity === activity.id && base.itemSelected]"
+                />
+              </ul>
+            </div>
+          </template>
+        </ActivitiesList>
+      </BaseWidthWrapper>
+    </BaseSectionWrapper>
+    
   </NavFooter>
 </template>
 
@@ -27,6 +101,7 @@ import ClearItems from '@/components/ClearItems.vue'
 import ChartItems from '@/components/ChartItems.vue'
 import NavFooter from '@/components/NavFooter.vue'
 import PrintPage from '@/components/PrintPage.vue'
+import ActivitiesItemAssessment from '@/components/ActivitiesItemAssessment.vue'
 import { activityTypes } from '@/components/mixins/activityTypes'
 import { dataMethods } from '@/components/mixins/dataMethods'
 import { bestPracticeData } from '@/components/mixins/bestPracticeData'
@@ -51,6 +126,7 @@ export default {
     ActivitiesItemResultPrint,
     ClearItems,
     ChartItems,
+    ActivitiesItemAssessment,
     NavFooter
   },
   computed: {
@@ -61,7 +137,7 @@ export default {
       return {
         left: [
           {
-            to: { name: 'advocate' },
+            to: {name: 'advocate'},
             label: this.$t('print.previousStep')
           }
         ],
@@ -121,5 +197,27 @@ export default {
 
 .toolTrayItem {
   display: inline-block;
+}
+
+.tableHeader {
+  composes: paddingBottom from "styles/spacing.scss";
+  display: block;
+
+  @supports (display: flex) {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+  }
+}
+
+.activityTypeList {
+  display: block;
+  list-style: none;
+  padding-left: 0;
+}
+
+.itemSelected {
+  background-color: rgba(color('accent'), 0.20);
 }
 </style>

--- a/src/views/Results.vue
+++ b/src/views/Results.vue
@@ -8,7 +8,7 @@
 
     <!-- Activities list -->
     <BaseSectionWrapper :class="space.paddingTop" border>
-      <BaseWidthWrapper width="xxwide">
+      <BaseWidthWrapper width="wide">
         <!-- Count & export tools -->
         <ActivitiesListHeader clearRecommendations />
 


### PR DESCRIPTION
This commit ensures that the global recommendations are visible in the
print view, and ensures that the ActivityNumber is used instead of the
Activity Text as the header on the results page EIP table.