### PR TITLE
Fix button stacking in footer

### DIFF
--- a/src/components/NavFooter.vue
+++ b/src/components/NavFooter.vue
@@ -10,7 +10,7 @@
       <div
         v-for="(group, index) in ['left', 'right']"
         :key="`navFooter-${index}`"
-        :class="base.buttonGroup"
+        :class="[base.buttonGroup, base[`buttonGroup${group}`]]"
       >
         <BaseGutterWrapper
           v-if="getGroupProp(group)"
@@ -128,6 +128,14 @@ export default {
   display: inline-block;
   width: 50%;
   text-transform: uppercase;
+}
+
+.buttonGroupleft {
+  width: 40%;
+}
+
+.buttonGroupright {
+  width: 60%;
 }
 
 .buttonWrapper {


### PR DESCRIPTION
This commit fixes an issue with button stacking in the nav footer when
we have buttons with a lot of text. This commit splits the nav 40/60
instead of 50/50. With the right side having more screen real estate.
This prevents the right buttons from stacking in french translations.