### PR TITLE
Always show EIP icons

### DIFF
--- a/src/components/ActivitiesItemAssessment.vue
+++ b/src/components/ActivitiesItemAssessment.vue
@@ -33,7 +33,6 @@
       <template slot="summaryRight">
         <!-- list of best practice icons -->
         <BaseGutterWrapper
-          v-if="youth"
           :class="base.right"
           el="ul"
           gutterX="xnarrow"
@@ -52,7 +51,7 @@
           </li>
         </BaseGutterWrapper>
         <!-- Edit -->
-        <BaseGutterWrapper v-else-if="editable" :class="[base.right, space.paddingHorizontalNone]" gutterY="xnarrow" gutterX="xnarrow">
+        <BaseGutterWrapper v-if="editable" :class="[base.right, space.paddingHorizontalNone]" gutterY="xnarrow" gutterX="xnarrow">
           <router-link
             :to="{ name: 'activity', params: { activityId: id } }"
             :class="base.rowAction"

--- a/src/components/NavItem.vue
+++ b/src/components/NavItem.vue
@@ -1,6 +1,13 @@
 <template>
   <li
-    :class="[this.parentIsActive && base.parentActive, this.isCurrentRoute && base.currentRoute, base.navItem, !link.active && base.navItemDisabled, base[getStepProgress]]"
+    :class="[
+      this.parentIsActive && base.parentActive, 
+      this.isCurrentRoute && base.currentRoute, 
+      base.navItem, 
+      !link.active && base.navItemDisabled, 
+      base[getStepProgress],
+      this.isFurthestStep && base.furthestStep
+      ]"
   >
     <router-link
       v-if="link.active"
@@ -42,6 +49,26 @@ export default {
     },
     isCurrentRoute: function () {
       return this.link.name === this.$route.name
+    },
+    isFurthestStep: function() {
+      const currentProgress = this.$store.getters.currentProgress
+      const progArray = Object.keys(currentProgress).map(step => {
+        return {name: step, active: currentProgress[step]}
+      });
+
+      const currentStep = progArray[this.objectIndex]
+      const nextStep = progArray[this.objectIndex + 1]
+
+      if (nextStep === undefined) {
+        return true;
+      }
+
+      if (nextStep && !nextStep.active) {
+        return true;
+      }
+
+      return false;
+      
     },
     parentIsActive: function () {
       // make sure there are children
@@ -165,13 +192,13 @@ $nav-breakpoint: 81em; // ~1400px
     color: color("primary");
   }
 
+  &:before {
+    background-color: color("primary");
+  }
+
   &:after {
     background-color: color("primary");
     height: 7px;
-  }
-
-  &:before {
-    background-color: color("primary");
   }
 
   &.whole {
@@ -184,6 +211,12 @@ $nav-breakpoint: 81em; // ~1400px
     &:after {
       width: 50%;
     }
+  }
+}
+
+.parentActive.furthestStep {
+  &:before {
+    background-color: color("midtone", $grade: 70);
   }
 }
 


### PR DESCRIPTION
This commit ensures that the EIP icons are always visible, regardless of
whether or not the activity is youth centric. It also tweaks the
progress bar a bit, having specific styles if the nav item is the
furthest progress item in the application.