### PR TITLE
Add fallback text for CountryIndicators

### DIFF
--- a/src/components/CountryIndicator.vue
+++ b/src/components/CountryIndicator.vue
@@ -1,10 +1,9 @@
 <template>
   <BaseGutterWrapper
-    v-if="!countryIndicator.error"
     :class="base.wrapper"
     el="section"
   >
-    <div :class="base.stats">
+    <div :class="base.stats" v-if="!countryIndicator.error">
       <BaseHeading
         :centered="false"
         :level="3"
@@ -44,10 +43,33 @@
       </div>
     </div>
     <ResultsQuestions
-      v-if="countryIndicator.questions"
+      v-if="countryIndicator.questions && !countryIndicator.error"
       :questions="countryIndicator.questions"
       :class="base.questions"
     />
+
+    <div :class="base.stats" v-else>
+      <BaseHeading
+        :centered="false"
+        :level="3"
+        scale="delta"
+        color="dark"
+        weight="bold"
+      >
+        {{countryIndicator.name}}
+      </BaseHeading>
+      <BaseHeading
+        :centered="false"
+        :level="5"
+        scale="zeta"
+        color="dark"
+        weight="light"
+        :class="space.paddingTopNarrow"
+      >
+        {{countryIndicator.error}}
+      </BaseHeading>
+    </div>
+
   </BaseGutterWrapper>
 </template>
 

--- a/src/components/NavItem.vue
+++ b/src/components/NavItem.vue
@@ -45,7 +45,6 @@ export default {
     },
     parentIsActive: function () {
       // make sure there are children
-      const fullPath = this.$route.fullPath.substring(1)
       if (this.link.steps) {
         if (this.link.name === this.$route.fullPath) {
           return true
@@ -66,7 +65,6 @@ export default {
       }
 
       // get the index of the route in the steps array
-      const inArray = this.$props.link.steps.filter(item => item.name === this.$route.name)
       const indexOfStep = this.$props.link.steps.findIndex(item => item.name === this.$route.name)
 
       if (indexOfStep >= 0) {

--- a/src/components/mixins/dataMethods.js
+++ b/src/components/mixins/dataMethods.js
@@ -58,12 +58,13 @@ export const dataMethods = {
       const indicator = this.$store.getters['entities/countryindicators/query']().where('indicatorId', indicatorId).first()
       var indicatorName = ''
       if (indicator) {
-        indicatorName = indicator.indicatorName
+        indicatorName = indicator.name
       } else {
         return { error: this.$t('indicatorNotPresent') }
       }
 
       // return country indicator
+      var countryName = this.getItemValue('setup', 'countryName')
       const countryIndicator = this.$store.getters['entities/countryindicators/query']()
         .where('indicatorId', indicatorId)
         .where('countryCode', this.getItemValue('setup', 'countryCode'))
@@ -71,7 +72,7 @@ export const dataMethods = {
       if (countryIndicator) {
         return countryIndicator
       } else {
-        return { error: this.$t('indicatorDataNotPresent', { indicatorName: indicatorName }) }
+        return { name: indicatorName, error: this.$t('indicatorDataNotPresent', { countryName: countryName }) }
       }
     },
     getBudgetTotal: function (queryObject) {

--- a/src/locales/en.yaml
+++ b/src/locales/en.yaml
@@ -1273,7 +1273,7 @@ en:
   addAnotherComment: Submit Comment
   bestPracticeIconData: Read more about this EIP
   # Country Indicator Data
-  indicatorDataNotPresent: 'Your country does not have data for %{indicatorName}'
+  indicatorDataNotPresent: 'This DHS info not available for %{countryName}'
   indicatorNotPresent: 'The indicator you have selected is not present'
   countryIndicators:
     indicator1:

--- a/src/locales/fr.yaml
+++ b/src/locales/fr.yaml
@@ -1373,7 +1373,7 @@ fr:
   addAnotherComment: Envoyer un Commentaire
   bestPracticeIconData: En savoir plus sur cette pratique fondée sur des données probantes (EIP)
   # Country Indicator Data
-  indicatorDataNotPresent: 'Votre pays ne dispose pas de données pour l''élément %{indicatorName}'
+  indicatorDataNotPresent: 'Votre pays ne dispose pas de données pour l''élément %{countryName}'
   indicatorNotPresent: 'L''indicateur que vous avez sélectionné n''est pas présent.'
   countryIndicators:
     indicator1:


### PR DESCRIPTION
This commit adds a fall back text for CountryIndicators in the Results
view. This text indicates that the data does not exist for the given
indicator and country pair.