### PR TITLE
Fix percentage error

### DIFF
--- a/src/components/ChartItems.vue
+++ b/src/components/ChartItems.vue
@@ -264,7 +264,6 @@ export default {
       })
 
       const activtyTypeCountRoundedPercentages = this.getRoundedPercentages(chartData.activityTypeData.map((item) => item.countPercent * 100))
-
       const activtyTypeCountLabel = chartData.activityTypeData.map((item, index) => {
         return {
           value: activtyTypeCountRoundedPercentages[index],

--- a/src/components/ChartLegend.vue
+++ b/src/components/ChartLegend.vue
@@ -25,7 +25,7 @@ export default {
       type: Array,
       required: true
     }
-  }
+  },
 }
 </script>
 

--- a/src/components/mixins/dataMethods.js
+++ b/src/components/mixins/dataMethods.js
@@ -109,9 +109,9 @@ export const dataMethods = {
         activityTypeData.push({
           type: activityType.title,
           count: activityCount,
-          countPercent: totalYouthActivities ? (activityCount / totalYouthActivities).toFixed(3) : 0.25,
+          countPercent: totalYouthActivities ? (activityCount / totalYouthActivities).toFixed(3) : 0,
           budgetAmount: this.getBudgetTotal(activityTypesObjects),
-          budgetPercent: totalYouthBudget ? (this.getBudgetTotal(activityTypesObjects) / totalYouthBudget).toFixed(3) : 0.25,
+          budgetPercent: totalYouthBudget ? (this.getBudgetTotal(activityTypesObjects) / totalYouthBudget).toFixed(3) : 0,
           class: activityType.key
         })
       }


### PR DESCRIPTION
This commit fixes an error with the budget chart labels. Specifically,
it addresses an issue where if there are no youth centric activities,
the budget will show 25% be allotted to each category, even though it
should read 0%.