### PR TITLE
Update pdf timestamp

### DIFF
--- a/src/components/mixins/electronPDF.js
+++ b/src/components/mixins/electronPDF.js
@@ -10,8 +10,16 @@ export const electronPDF = {
       var pdfSuccess = false
 
       // Create temp path
-      const timestamp = Date.now()
-      const pdfPath = path.join(os.tmpdir(), this.$t('fileUpload.pdfFileName', { timestamp: timestamp }))
+      const formatDate = () => {
+        const stamp = new Date()
+        const month = stamp.getMonth()
+        const day = stamp.getDate()
+        const year = stamp.getYear()
+
+        return `${day}-${month}-${year}`
+      }
+
+      const pdfPath = path.join(os.tmpdir(), this.$t('fileUpload.pdfFileName', { timestamp: formatDate() }))
 
       const currentWindow = remote.getCurrentWindow()
       const pdfViewWindow = new remote.BrowserWindow({ show: false, width: 1500, height: 1500, webPreferences: { plugins: true } })


### PR DESCRIPTION
In order to overwrite the saved pdf, but still maintain a
timestamp/version of the saved pdf, this commit updates the timestamp
used. Instead of using a unix timestamp as the pdf suffix, this commit
uses the dd-mm-yyyy format as the suffix. This will allow users to
overwrite pdfs on the same day, while working, and also maintain a
version history when working over several days.