### PR TITLE
Fix ie11 styles for activites tray

### DIFF
--- a/src/components/ActivitiesList.vue
+++ b/src/components/ActivitiesList.vue
@@ -118,19 +118,15 @@ export default {
   composes: darkBorder from "styles/color.scss";
   composes: paddingVerticalXxnarrow from "styles/spacing.scss";
 
-  @supports (display: flex) {
-    display: flex;
-    justify-content: flex-end;
-  }
+  display: flex;
+  justify-content: flex-end;
 }
 
 .headerRightPane {
   max-width: 58.3333%;
 
-  @supports (display: flex) {
-    display: flex;
-    justify-content: flex-end;
-  }
+  display: flex;
+  justify-content: flex-end;
 }
 
 .heading {

--- a/src/components/ActivitiesListHeader.vue
+++ b/src/components/ActivitiesListHeader.vue
@@ -100,6 +100,7 @@ export default {
     justify-content: space-between;
     align-items: center;
     flex-wrap: wrap;
+    flex-direction: row;
   }
 }
 </style>

--- a/src/components/BaseFormSwitch.vue
+++ b/src/components/BaseFormSwitch.vue
@@ -9,7 +9,8 @@
       :class="[base.switch, { [base.enhanced]: supportStyledCheckbox }]"
       :name="name"
       :id="name"
-      v-model="value"
+      v-model="renderedValue"
+      :value="renderedValue"
       :data-label-on="labelOn || $t('yesRaw')"
       :data-label-off="labelOff || $t('noRaw')"
       type="checkbox"
@@ -52,7 +53,8 @@ export default {
   },
   data() {
     return {
-      supportStyledCheckbox: false
+      supportStyledCheckbox: false,
+      renderedValue: this.value
     };
   },
   created() {

--- a/src/components/TableHeading.vue
+++ b/src/components/TableHeading.vue
@@ -33,6 +33,7 @@ export default {
   max-width: 55px;
   margin: 0 10px;
   position: relative;
+  display: inline-block;
 
   &:hover {
     .fieldDesc {


### PR DESCRIPTION
This commit fixes the header of the activites tray, ensuring that flex box
styles are applied on ie11 browsers. It also fixes an issue with the
checkbox on chrome, where the value was not being updated correctly.